### PR TITLE
README: fix typo in git clone URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ please raise an
 
 ```bash
 git clone https://github.com/tpope/vim-repeat ~/.vim/bundle/vim-repeat
-git clone https://github.com/bergercookie/vim-debustring.git ~/.vim/bundle/vim-debugstring
+git clone https://github.com/bergercookie/vim-debugstring.git ~/.vim/bundle/vim-debugstring
 
 ```
 


### PR DESCRIPTION
there's a minor typo in `git clone` command. I found it by just copy-n-paste the install instruction